### PR TITLE
Make cv::cuda available.

### DIFF
--- a/Cpp/AutoWhiteBalance.h
+++ b/Cpp/AutoWhiteBalance.h
@@ -17,6 +17,8 @@ This algorithm is implemented based on google's two papers:
 #include <memory>
 // opencv
 #include <opencv2/opencv.hpp>
+#include <opencv2/cudawarping.hpp>
+#include <opencv2/cudaarithm.hpp>
 
 class AutoWhiteBalance {
 private:


### PR DESCRIPTION
There were some compilation errors at functions in cv::cuda, `cv::cuda::resize`, `cv::cuda::dft`, etc.
By importing these 2 .hpp files, the compilation could be done successfully.